### PR TITLE
Add subgraph manifest creation step to build guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ generated
 
 # auto-generated
 subgraph.yaml
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ npm i
 ## Building the graph
 
 ```shell
+# create subgraph manifest
+npm run prepare:ropsten
+
 # compile types
 npm run codegen
 


### PR DESCRIPTION
`npm run codegen` would not execute without the generated manifest.